### PR TITLE
Resolve Issue #2 Appending a DataFrame with string columns fails: Utf8View vs Utf8 schema mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.3 (unreleased)
+
+- Fixed appending data frames with string, binary, and non-microsecond timestamp columns
+
 ## 0.11.2 (2026-05-14)
 
 - Updated Iceberg Rust to 0.9.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2872,6 +2872,7 @@ name = "iceberg-ruby"
 version = "0.11.2"
 dependencies = [
  "arrow-array",
+ "arrow-cast",
  "arrow-schema",
  "datafusion",
  "futures",

--- a/ext/iceberg/Cargo.toml
+++ b/ext/iceberg/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 arrow-array = { version = "57", features = ["ffi"] }
+arrow-cast = "57"
 arrow-schema = "57"
 datafusion = { version = "52", optional = true }
 futures = "0.3"

--- a/ext/iceberg/src/table.rs
+++ b/ext/iceberg/src/table.rs
@@ -1,4 +1,7 @@
+use arrow_array::RecordBatch;
 use arrow_array::ffi_stream::ArrowArrayStreamReader;
+use arrow_cast::cast;
+use arrow_schema::{ArrowError, DataType};
 use iceberg::TableIdent;
 use iceberg::io::FileIO;
 use iceberg::spec::FormatVersion;
@@ -88,7 +91,7 @@ impl RbTable {
                     runtime.block_on(data_file_writer_builder.build(None))?;
 
                 for batch in data.0 {
-                    let batch = batch.unwrap().with_schema(table_schema.clone())?;
+                    let batch = cast_batch(batch.unwrap(), &table_schema)?;
                     runtime.block_on(data_file_writer.write(batch))?;
                 }
 
@@ -433,4 +436,50 @@ impl RbTable {
             table: static_table.into_table().into(),
         })
     }
+}
+
+// Polars 1.x+ streams strings as Utf8View, binary as BinaryView, and
+// timestamps in their native unit, while the table's Arrow schema uses
+// Utf8/Binary/Timestamp(us). These conversions are lossless, but
+// RecordBatch::with_schema only relabels and rejects any physical-type
+// difference, so they need a real cast.
+fn cast_compatible(from: &DataType, to: &DataType) -> bool {
+    match (from, to) {
+        (DataType::Utf8View | DataType::LargeUtf8, DataType::Utf8) => true,
+        (DataType::BinaryView | DataType::LargeBinary, DataType::Binary) => true,
+        (DataType::Timestamp(_, from_tz), DataType::Timestamp(_, to_tz)) => from_tz == to_tz,
+        _ => false,
+    }
+}
+
+fn cast_batch(
+    batch: RecordBatch,
+    target: &Arc<arrow_schema::Schema>,
+) -> Result<RecordBatch, ArrowError> {
+    let compatible = batch.num_columns() == target.fields().len()
+        && batch
+            .columns()
+            .iter()
+            .zip(target.fields())
+            .all(|(column, field)| {
+                column.data_type() == field.data_type()
+                    || cast_compatible(column.data_type(), field.data_type())
+            });
+    if !compatible {
+        // keep with_schema's "not superset" error for genuine schema mismatches
+        return batch.with_schema(target.clone());
+    }
+    let columns = batch
+        .columns()
+        .iter()
+        .zip(target.fields())
+        .map(|(column, field)| {
+            if column.data_type() == field.data_type() {
+                Ok(column.clone())
+            } else {
+                cast(column, field.data_type())
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    RecordBatch::try_new(target.clone(), columns)
 }

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -90,6 +90,33 @@ class TableTest < Minitest::Test
     assert_frame_equal df, table.to_polars.collect
   end
 
+  def test_append_string_and_timestamp
+    df = Polars::DataFrame.new([
+      Polars::Series.new("id", [1, 2, 3], dtype: Polars::Int64),
+      Polars::Series.new("name", ["a", "b", "c"], dtype: Polars::String),
+      Polars::Series.new("ts", [Time.at(1_720_000_000), Time.at(1_720_000_001), Time.at(1_720_000_002)], dtype: Polars::Datetime.new("ns"))
+    ])
+    table = catalog.create_table("iceberg_ruby_test.events") do |t|
+      t.bigint "id"
+      t.string "name"
+      t.timestamp "ts"
+    end
+    assert_nil table.append(df)
+    refute_nil table.current_snapshot_id
+
+    # Polars.scan_iceberg does not support string or timestamp columns yet,
+    # so read the parquet data files directly on local warehouses
+    if memory? || sql?
+      data_files = table.scan.plan_files.map { |f| f[:data_file_path].delete_prefix("file://") }
+      refute_empty data_files
+      result = Polars.read_parquet(data_files).sort("id")
+      assert_equal [1, 2, 3], result["id"].to_a
+      assert_equal ["a", "b", "c"], result["name"].to_a
+      assert_equal Polars::Datetime.new("us"), result["ts"].dtype
+      assert_equal [1_720_000_000, 1_720_000_001, 1_720_000_002], result["ts"].to_a.map(&:to_i)
+    end
+  end
+
   def test_append_column_order
     df = Polars::DataFrame.new({"a" => [1, 2, 3], "b" => [4, 5, 6]})
     table = catalog.create_table("iceberg_ruby_test.events", schema: df.schema)


### PR DESCRIPTION

`Table#append` fails for any DataFrame containing a string column:

```ruby
catalog = Iceberg::MemoryCatalog.new(warehouse: dir)
catalog.create_namespace("a")
df = Polars::DataFrame.new({"id" => [1], "s" => ["x"]}, schema_overrides: {"s" => Polars::String})
catalog.create_table("a.t1", schema: df.schema)
catalog.load_table("a.t1").append(df)
# ArgumentError: Arrow Schema Error, source: Schema error: target schema is not superset of
# current schema target=... Field { "s": nullable Utf8 } current=... Field { "s": nullable Utf8View }
```

Cause: polars ≥ 1.x exports strings over the Arrow C stream as `Utf8View` (and binary as `BinaryView`, timestamps as ns) — spec-compliant modern Arrow — while `RbTable::append`(`ext/iceberg/src/table.rs`) passes each batch through `RecordBatch::with_schema`, which only *relabels* and errors on any physical-type difference. Since `Utf8View → Utf8` (and `Timestamp(ns) → Timestamp(µs)`) are lossless casts that arrow-rs's `cast` kernel supports, replacing the relabel with a per-column cast-when-different fixes string, binary, and timestamp-unit appends in one change. The existing `test_append` only covers Int32/Int64/Float32/Float64/Boolean, so none of this is exercised in CI.

Versions: iceberg 0.11.2 (precompiled arm64-darwin & x86_64-linux), polars-df 0.26.0, Ruby 3.3.10.

This fix is meant to close issue #2 